### PR TITLE
add: Options `bindUser` and `bindPassword`

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -67,8 +67,10 @@ Strategy.prototype.authenticate = function(req, options) {
     var client = ldap.createClient(this.options.server);
 
     // Bind to LDAP server
-    var dn = this.options.uidTag + '=' + username + ',' + this.options.base;
-    client.bind(dn, password, function(err) {
+    var bindUser = this.options.bindUser || username;
+    var bindPassword = this.options.bindPassword || password;
+    var dn = this.options.uidTag + '=' + bindUser  + ',' + this.options.base;
+    client.bind(dn, bindPassword, function(err) {
         if (err) {
             // Invalid credentials / user not found are not errors but login failures
             if (err.name === 'InvalidCredentialsError' || err.name === 'NoSuchObjectError' ||


### PR DESCRIPTION
To be able to use a different user for bind request,
which is required by some LDAP security strategy.

Linked to issue #3 